### PR TITLE
Fix `staticcheck` issue

### DIFF
--- a/base32_test.go
+++ b/base32_test.go
@@ -127,7 +127,7 @@ func TestDecoder(t *testing.T) {
 		testEqual(t, "Read from %q = length %v, want %v", p.encoded, count, len(p.decoded))
 		testEqual(t, "Decoding of %q = %q, want %q", p.encoded, string(dbuf[0:count]), p.decoded)
 		if err != io.EOF {
-			count, err = decoder.Read(dbuf)
+			_, err = decoder.Read(dbuf)
 		}
 		testEqual(t, "Read from %q = %v, want %v", p.encoded, err, io.EOF)
 	}
@@ -362,4 +362,3 @@ func TestNoPaddingRand(t *testing.T) {
 		}
 	}
 }
-

--- a/go.mod
+++ b/go.mod
@@ -1,1 +1,3 @@
 module github.com/multiformats/go-base32
+
+go 1.15


### PR DESCRIPTION
Fixe `SA4006` warning on unused variable in testing

Add go version to `go.mod` as `1.15`

Relates to:

- https://github.com/orgs/ipfs/projects/12#card-58209321